### PR TITLE
Remove duplicate word in Notation section of the documentation

### DIFF
--- a/docs/src/notation.md
+++ b/docs/src/notation.md
@@ -82,7 +82,7 @@ itself need not be escaped.
     htl"<span>\some\path</span>"
     #-> <span>\some\path</span>
 
-To represent the dollar-sign, use use HTML character entity `#&36;`.
+To represent the dollar-sign, use HTML character entity `#&36;`.
 
     amount = 42
 


### PR DESCRIPTION
Remove double usage of `use` word