### PR TITLE
Allow interpolating tag name

### DIFF
--- a/docs/src/attribute.md
+++ b/docs/src/attribute.md
@@ -202,6 +202,36 @@ of CSS classes and a custom style.
     print(@htl "<div $style>Hello</div>")
     #-> <div class='one two' style='background-color: #92a8d1;'>Hello</div>
 
+## Tag name interpolation
+
+To dynamically set the tag name, you put the interpolation right where
+you would normally put the tag name.
+
+    tagname = "div"
+    @htl """<$tagname class=active></$tagname>"""
+    #-> <div class=active></div>
+
+In case of custom components, you might want to extend the tagname.
+This also is possible.
+
+    tagname = "code"
+    @htl """<htl-$tagname class=julia>import HypertextLiteral</htl-$tagname>"""
+    #-> <htl-code class=julia>import HypertextLiteral</htl-code>
+
+    prefix = "htl"
+    @htl """<$prefix-code class=julia>import HypertextLiteral</$prefix-code>"""
+    #-> <htl-code class=julia>import HypertextLiteral</htl-code>
+
+Tag names are very strict, thus we can't use complex objects.
+
+    complex_prefix = Dict(:class => :julia)
+    @htl """<$complex_prefix>import HypertextLiteral</$complex_prefix>"""
+    #-> ERROR: "Can't use complex objects as tag name"
+
+    invalid_tag = "import HypertextLiteral"
+    @htl """<$invalid_tag></$invalid_tag>"""
+    #-> ERROR: "Content within a tag name can only contain [a-zA-Z_]"
+
 ## Style Tag
 
 Within a `<style>` tag, Julia values are interpolated using the same

--- a/docs/src/attribute.md
+++ b/docs/src/attribute.md
@@ -226,15 +226,54 @@ This also is possible.
     @htl """<$prefix-code class=julia>import HypertextLiteral</$prefix-code>"""
     #-> <htl-code class=julia>import HypertextLiteral</htl-code>
 
-Tag names are very strict, thus we can't use complex objects.
+Because with tags there isn't much fancy interpolation work we can do,
+you can't put in any complex object.
 
     complex_prefix = Dict(:class => :julia)
     @htl """<$complex_prefix>import HypertextLiteral</$complex_prefix>"""
     #-> ERROR: "Can't use complex objects as tag name"
 
-    invalid_tag = "import HypertextLiteral"
-    @htl """<$invalid_tag></$invalid_tag>"""
-    #-> ERROR: "Content within a tag name must not contain spaces"
+A tag name _can_ be very flexible, in Chrome `<a™^Î>` is a valid tag name.
+Stricly, only the first character has to be `/[a-z]/i`,
+and the rest can be anything but `/`, `>` and ` ` (space).
+(Yes, theoretically, you can have a `<` in your tag name).
+
+    contains_space = "import HypertextLiteral"
+    @htl """<$contains_space></$contains_space>"""
+    #-> ERROR: "Content within a tag name can only contain latin letters, numbers or hyphens (`-`)"
+
+    contains_bigger_than = "a<div>"
+    @htl """<$contains_bigger_than></$contains_bigger_than>"""
+    #-> ERROR: "Content within a tag name can only contain latin letters, numbers or hyphens (`-`)"
+
+    contains_slash = "files/extra.js"
+    @htl """<$contains_slash></$contains_slash>"""
+    #-> ERROR: "Content within a tag name can only contain latin letters, numbers or hyphens (`-`)"
+
+    starts_with_hyphen = "-secret-tag-name"
+    @htl """<$starts_with_hyphen></$starts_with_hyphen>"""
+    #-> ERROR: "A tag name can only start with letters, not `-`"
+
+    empty = ""
+    @htl """<$empty></$empty>"""
+    #-> ERROR: "A tag name can not be empty"
+
+But I figured, better safe than sorry, let's only allow characters people commonly use.
+(We can always make this less restrictive, but making it more restrictive would be a breaking change)
+Also, until someone finds it necessary to implement this, we treat tags with a prefix as
+tag names, thus requiring it to be non-empty and not start with a hyphen.
+
+    technically_valid_but_weird = "Technically⨝ValidTag™"
+    @htl """<$technically_valid_but_weird></$technically_valid_but_weird>"""
+    #-> ERROR: "Content within a tag name can only contain latin letters, numbers or hyphens (`-`)"
+
+    technically_valid_starts_with_hyphen = "-secret-tag-name"
+    @htl """<prefix$technically_valid_starts_with_hyphen></prefix$technically_valid_starts_with_hyphen>"""
+    #-> ERROR: "A tag name can only start with letters, not `-`"
+
+    technically_valid_empty = ""
+    @htl """<prefix-$technically_valid_empty></prefix-$technically_valid_empty>"""
+    #-> ERROR: "A tag name can not be empty"
 
 ## Style Tag
 

--- a/docs/src/attribute.md
+++ b/docs/src/attribute.md
@@ -230,7 +230,7 @@ Tag names are very strict, thus we can't use complex objects.
 
     invalid_tag = "import HypertextLiteral"
     @htl """<$invalid_tag></$invalid_tag>"""
-    #-> ERROR: "Content within a tag name can only contain [a-zA-Z_]"
+    #-> ERROR: "Content within a tag name must not contain spaces"
 
 ## Style Tag
 

--- a/docs/src/attribute.md
+++ b/docs/src/attribute.md
@@ -211,6 +211,10 @@ you would normally put the tag name.
     @htl """<$tagname class=active></$tagname>"""
     #-> <div class=active></div>
 
+    tagname = "htl-code-block"
+    @htl """<$tagname class=active></$tagname>"""
+    #-> <htl-code-block class=active></htl-code-block>
+
 In case of custom components, you might want to extend the tagname.
 This also is possible.
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -198,8 +198,8 @@ suitable for tag names.
 """
 
 function tag_name(x::String)
-    if occursin(r"[^a-zA-Z_]", x)
-        throw("Content within a tag name can only contain [a-zA-Z_]")
+    if occursin(" ", x)
+        throw("Content within a tag name must not contain spaces")
     else
         x
     end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -193,13 +193,19 @@ inside_tag(::Nothing) = no_content
 """
     tag_name(x)
 
-This method may be implemented to specify a printed representation
-suitable for tag names.
+Tag names need to start with `/[a-z]/i`,
+and can't contain any spaces, `>` or `/`.
+Although technically all other characters would be valid,
+we only allow letters, numbers and hyphens for now.
 """
 
 function tag_name(x::String)
-    if occursin(" ", x)
-        throw("Content within a tag name must not contain spaces")
+    if isempty(x)
+        throw("A tag name can not be empty")
+    elseif !occursin(r"^[a-z]"i, x)
+        throw("A tag name can only start with letters, not `$(x[1])`")
+    elseif occursin(r"[^a-z0-9-]", x)
+        throw("Content within a tag name can only contain latin letters, numbers or hyphens (`-`)")
     else
         x
     end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -189,3 +189,20 @@ inside_tag(values::NamedTuple) =
     inside_tag(pairs(values))
 
 inside_tag(::Nothing) = no_content
+
+"""
+    tag_name(x)
+
+This method may be implemented to specify a printed representation
+suitable for tag names.
+"""
+
+function tag_name(x::String)
+    if occursin(r"[^a-zA-Z_]", x)
+        throw("Content within a tag name can only contain [a-zA-Z_]")
+    else
+        x
+    end
+end
+tag_name(x::Symbol) = tag_name(string(x))
+tag_name(x::Any) = throw("Can't use complex objects as tag name")

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -99,6 +99,16 @@ function interpolate(args)
                     end
                 end
                 append!(parts, rewrite_inside_tag(input))
+            elseif state == STATE_TAG_OPEN
+                push!(parts, esc(input))
+                # Not setting tag-open so it doesn't try to parse this fetch the element-name later
+                # (Because we can't get the element name from a binding during macro analysis)
+                state = STATE_TAG_NAME
+            elseif state == STATE_END_TAG_OPEN
+                push!(parts, :(tag_name($(esc(input)))))
+                state = STATE_TAG_NAME
+            elseif state === STATE_TAG_NAME
+                push!(parts, :(tag_name($(esc(input)))))
             else
                 throw("unexpected binding $(state)")
             end


### PR DESCRIPTION
Turns out I needed this earlier than I was expecting 😛
But honestly, I can't go back to `html"`, `@htl` is too good!

This allows stuff like 

```julia
tagname = "textarea"
@htl "<$tagname></$tagname>"
#-> <textarea></textarea>

# But also
@htl "<pluto-$tagname></pluto-$tagname>"
#-> <pluto-textarea></pluto-textarea>
```

I'm not sure what is best for the `tag_name` stuff, honestly I think people shouldn't even extend this, just use a string or symbol if you want a tag name 🤷‍♀️

Also, I like NarrativeTest.jl more than I was expecting to like it :D